### PR TITLE
Restore functionality after another class change by Google

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -48,7 +48,7 @@ const redditIcon = '<svg foscusable="false" xmlns="http://www.w3.org/2000/svg" w
         var toolsBtn = document.getElementById('hdtb-tls');
         toolsBtn.parentNode.insertBefore(el, toolsBtn.nextSibling);
     } else {
-        var button = document.getElementById('hdtb-msb-vis');
+        var button = document.querySelector('.MUFPAc');
         button.appendChild(el);
     }
 })();


### PR DESCRIPTION
Greetings


The script had stopped working  after a class change by Google once more: 
I was getting (with Tampermonkey in Chrome) :

>  `Uncaught (in promise) TypeError: Cannot read property 'appendChild' of null`
   
with line 52: `button.appendChild(el);`

This PR updates the `button` selector.

PS. Thank you for your useful script.