### PR TITLE
Fix Flash of Unstyled Content

### DIFF
--- a/userscript.js
+++ b/userscript.js
@@ -1,6 +1,6 @@
 // ==UserScript==
 // @name         Reddit search on Google
-// @version      1.3.2
+// @version      1.3.3
 // @description  Adds a button to search Reddit posts with Google
 // @author       Mario O.M.
 // @namespace    https://github.com/marioortizmanero/reddit-search-on-google/
@@ -31,6 +31,7 @@ const redditIcon = '<svg foscusable="false" xmlns="http://www.w3.org/2000/svg" w
     if (useIcon) {
         var span = document.createElement('span');
         span.className = 'bmaJhd iJddsb';
+        span.style.cssText = 'height:16px;width:16px';
         span.innerHTML += redditIcon;
         link.appendChild(span);
     }


### PR DESCRIPTION
Google seems to have changed some CSS again. Now while page loading, the reddit icon flashes in 300x300px, also it blows up to 300x300px when zooming in the browser.
Adding `style="height:16px;width:16px"` to the `span`, like Google's other icons have, fixes the issue.